### PR TITLE
build(deps): Bump Microsoft.Extensions.Http from 8.0.0 to 9.0.13

### DIFF
--- a/Jellyfin.Plugin.PhoenixAdult/PhoenixAdult.csproj
+++ b/Jellyfin.Plugin.PhoenixAdult/PhoenixAdult.csproj
@@ -77,7 +77,7 @@
 
   <ItemGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='Release'">
     <PackageReference Include="Jellyfin.Controller" Version="10.11.8" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.13" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug.Emby' or '$(Configuration)'=='Release.Emby'">


### PR DESCRIPTION
## 修改内容
将 `Microsoft.Extensions.Http` 从 8.0.0 升级到 **9.0.13**。

## 背景
dependabot 之前提了 PR #65 升级到 10.0.7,但存在运行时风险:
- Jellyfin 10.11 系列锁定 Microsoft.Extensions.* 为 **9.0.x**(Directory.Packages.props 9.0.10 / Jellyfin.Controller 10.11.8 传递依赖 9.0.11)
- Microsoft.Extensions.Http 10.0.7 的 AssemblyVersion 是 10.0.0.0,.NET Core 运行时**不会降级绑定**到宿主已加载的 9.0.0.0,插件加载时会抛 FileNotFoundException
- 而 9.0.x 系列的 AssemblyVersion 同为 9.0.0.0,运行时直接复用宿主程序集,无绑定问题

## 验证
- `dotnet build -c Release`:**0 警告 0 错误**,ILRepack 正常,zip 产物正常
- 依赖链全部解析为 9.0.x(9.0.13 主体 + Caching 9.0.10),无 10.x 混入
- 与 Jellyfin.Controller 10.11.8(Jellyfin 10.11 系列)版本对齐